### PR TITLE
Remove purrr dependency.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wordpiece
 Type: Package
 Title: R Implementation of Wordpiece Tokenization
-Version: 2.2.0
+Version: 2.1.2
 Authors@R: c(
     person(given = "Jonathan",
            family = "Bratt",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wordpiece
 Type: Package
 Title: R Implementation of Wordpiece Tokenization
-Version: 2.1.1
+Version: 2.2.0
 Authors@R: c(
     person(given = "Jonathan",
            family = "Bratt",
@@ -31,7 +31,6 @@ Imports:
     fastmatch (>= 1.1),
     memoise (>= 2.0.0),
     piecemaker (>= 1.0.0),
-    purrr (>= 0.2.3),
     rlang,
     stringi (>= 1.0),
     wordpiece.data (>= 1.0.2)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# wordpiece 2.2.0
+
+* Removed purrr dependency. (#30, @jonthegeek)
+
+# wordpiece 2.1.0
+
+* Implemented various speed improvements, improving speed and memory usage by over 1000x. (#27, @jonathanbratt)
+
 # wordpiece 2.0.0
 
 * Refactored `wordpiece_tokenize` to accept a character vector with length > 1. This makes the package more usable within a workflow, but will break scripts that used the previous version (the output is now a list of character vectors, instead of a single character vector). (@jonthegeek)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,7 @@
-# wordpiece 2.2.0
-
-* Removed purrr dependency. (#30, @jonthegeek)
-
 # wordpiece 2.1.0
 
 * Implemented various speed improvements, improving speed and memory usage by over 1000x. (#27, @jonathanbratt)
+* Removed purrr dependency. (#30, @jonthegeek)
 
 # wordpiece 2.0.0
 

--- a/R/tokenization.R
+++ b/R/tokenization.R
@@ -50,9 +50,9 @@ wordpiece_tokenize <- function(text,
     remove_terminal_hyphens = FALSE
   )
 
-  tokens <- purrr::map(
-    text,
-    .f = .wp_tokenize_single_string,
+  tokens <- lapply(
+    X = text,
+    FUN = .wp_tokenize_single_string,
     vocab = vocab,
     unk_token = unk_token,
     max_chars = max_chars
@@ -76,9 +76,9 @@ wordpiece_tokenize <- function(text,
                                        unk_token,
                                        max_chars) {
   token_vector <- unlist(
-    purrr::map(
-      words,
-      .f = .wp_tokenize_word,
+    lapply(
+      X = words,
+      FUN = .wp_tokenize_word,
       vocab = vocab,
       unk_token = unk_token,
       max_chars = max_chars


### PR DESCRIPTION
Closes #30.

```
# A tibble: 2 x 3
  expression   median mem_alloc
  <bch:expr> <bch:tm> <bch:byt>
1 purrr         355ms    3.36MB
2 base          257ms    2.53MB
```